### PR TITLE
[cosmos] quicksync skip checksum flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,7 +142,7 @@ The `trustwallet-blockchain-x.x.x.tar.gz` file will appear at the root of the pr
 It can be installed for local testing by executing the following command:
 
 ```sh
-ansible-galaxy collection install trustwallet-blockchain-0.3.4.tar.gz --force
+ansible-galaxy collection install trustwallet-blockchain-0.x.x.tar.gz --force
 ```
 
 ## References

--- a/docs/cosmos_role.md
+++ b/docs/cosmos_role.md
@@ -57,9 +57,9 @@ until it is at the current height (we have already set this variable in `vars/te
   become: true
 
   roles:
-    - roles: gantsign.golang
+    - role: gantsign.golang
       golang_version: "1.18.1"
-      golang_install_dir: /usr/local
+      golang_install_dir: /usr/local/go
 
     - role: trustwallet.blockchain.cosmos
       chain_name: osmosis

--- a/galaxy.yml
+++ b/galaxy.yml
@@ -1,7 +1,7 @@
 ---
 namespace: trustwallet
 name: blockchain
-version: 0.3.4
+version: 0.3.5
 readme: README.md
 authors:
   - vorotech

--- a/molecule/cosmos/converge.yml
+++ b/molecule/cosmos/converge.yml
@@ -9,6 +9,6 @@
         ansible_become: true
         chain_name: "{{ lookup('env', 'COSMOS_CHAIN_NAME') }}"
         chain_git_repo: https://github.com/osmosis-labs/osmosis
-        #chain_bin_url: https://github.com/osmosis-labs/osmosis/releases/download/v6.4.0/osmosisd-6.4.0-linux-amd64
+        # chain_bin_url: https://github.com/osmosis-labs/osmosis/releases/download/v6.4.0/osmosisd-6.4.0-linux-amd64
         chain_version: v7.2.0
         quicksync_mode: none

--- a/molecule/cosmos/converge.yml
+++ b/molecule/cosmos/converge.yml
@@ -9,5 +9,6 @@
         ansible_become: true
         chain_name: "{{ lookup('env', 'COSMOS_CHAIN_NAME') }}"
         chain_git_repo: https://github.com/osmosis-labs/osmosis
+        #chain_bin_url: https://github.com/osmosis-labs/osmosis/releases/download/v6.4.0/osmosisd-6.4.0-linux-amd64
         chain_version: v7.2.0
         quicksync_mode: none

--- a/molecule/cosmos/prepare.yml
+++ b/molecule/cosmos/prepare.yml
@@ -16,3 +16,4 @@
   roles:
     - role: gantsign.golang
       golang_version: "1.18.1"
+      golang_install_dir: /usr/local/go

--- a/roles/cosmos/defaults/main.yml
+++ b/roles/cosmos/defaults/main.yml
@@ -80,6 +80,10 @@ quicksync_force: false
 # assuming that the file has been already downloaded.
 quicksync_skip_download: false
 
+# <quicksync_skip_download> skips steps to perform the checksum over downloaded archive,
+# quicksync.io has issues recently with checksum integrity.
+quicksync_skip_checksum: false
+
 # <quicksync_target_url> allows to override target url to download chain data archive
 # e.g. quicksync_target_url: <custom state url>
 

--- a/roles/cosmos/tasks/install.yml
+++ b/roles/cosmos/tasks/install.yml
@@ -70,7 +70,7 @@
         version: "{{ chain_version }}"
 
     - name: "Make {{ chain_name }} binary" # noqa no-changed-when
-      ansible.builtin.command: "make install"
+      ansible.builtin.shell: "{{ make_command | default('make install') }}"
       args:
         chdir: "/tmp/{{ chain_name }}"
       environment:

--- a/roles/cosmos/tasks/sync.yml
+++ b/roles/cosmos/tasks/sync.yml
@@ -57,20 +57,26 @@
     url: "{{ target_url }}.checksum"
     dest: "{{ quicksync_tmp_dir }}"
     mode: "755"
-  when: not quicksync_skip_download
+  when:
+    - not quicksync_skip_download
+    - not quicksync_skip_checksum
 
 - name: "Copy checksum tool"
   ansible.builtin.copy:
     src: checksum.sh
     dest: "{{ quicksync_tmp_dir }}"
     mode: "755"
-  when: not quicksync_skip_download
+  when:
+    - not quicksync_skip_download
+    - not quicksync_skip_checksum
 
 - name: "Checksum downloaded archive"
   ansible.builtin.command:
     cmd: "./checksum.sh {{ target_filename }}"
     chdir: "{{ quicksync_tmp_dir }}"
-  when: not quicksync_skip_download
+  when:
+    - not quicksync_skip_download
+    - not quicksync_skip_checksum
 
 - name: "Stop service (if running)"
   ansible.builtin.systemd:

--- a/roles/cosmos/vars/osmosis.yml
+++ b/roles/cosmos/vars/osmosis.yml
@@ -2,3 +2,7 @@
 chain_minimum_gas_prices: "0.001uosmo"
 chain_addrbook_url: https://quicksync.io/addrbook.osmosis.json
 quicksync_available: true
+make_command: >
+  wget https://github.com/CosmWasm/wasmvm/releases/download/v1.0.0-beta7/libwasmvm_muslc.a -O /lib/libwasmvm_muslc.a &&
+  BUILD_TAGS=muslc make build &&
+  cp ./build/osmosisd {{ bin_dir }}


### PR DESCRIPTION
## Changes

* Introduced a `quicksync_skip_checksum` cosmos role variable (default to `false`) to fix some issues related to downloading and checking the `osmosis` chain data with https://quicksync.io
* Fixed the `osmosis` chain binary build (see https://github.com/osmosis-labs/osmosis/issues/1284) 