### PR TITLE
bump near version to 1.29.0

### DIFF
--- a/roles/near/defaults/main.yml
+++ b/roles/near/defaults/main.yml
@@ -6,7 +6,7 @@ username: near
 home_dir: "/home/{{ username }}"
 
 # <near_version> is the near binary version. When doesn't match, will rebuild binary from sources.
-near_version: 1.28.0
+near_version: 1.29.0
 
 # <near_bin> is the chain executable
 near_bin: /usr/local/bin/neard


### PR DESCRIPTION
Warning: See configuration changes https://github.com/near/nearcore/releases/tag/1.29.0 there is a mandatory action need to be taken for nodes upgraded from 1.28.0